### PR TITLE
Add lint workflow for GHA

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,5 +22,5 @@ jobs:
         with:
           python-version: 3.11.4
 
-      - name: Run linters
+      - name: Run pre-commit
         uses: pre-commit/action@v3.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+---
+name: lint
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: 3.11.4
+
+      - name: Run linters
+        uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,11 @@ repos:
       - id: isort
         args: [--profile=black]
 
-# - repo: https://github.com/psf/black
-#   rev: 23.7.0
-#   hooks:
-#     - id: black
-#       args: [--line-length=79]
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        args: [--line-length=79]
 
 # - repo: https://github.com/pre-commit/mirrors-mypy
 #   rev: v1.5.1


### PR DESCRIPTION
By running pre-commit in CI we can ensure linter rules are being enforced uniformly.
